### PR TITLE
add failing test for both types of files

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -82,6 +82,62 @@ describe('Fix Module Folders', function() {
         expect(output.changes()).to.deep.equal({});
       }));
 
+      it('should handle files in both modules folder and root', co.wrap(function*() {
+        // INITIAL
+        input.write({
+          'modules': {
+            'ember-data': {
+              'index.js': `exports { * } from './whatever'`
+            }
+          },
+          'ember-inflector': {
+            'index.js': `exports { * } from './whateverElse'`
+          }
+        });
+
+        yield output.build();
+
+        expect(output.read()).to.deep.equal({
+          'ember-data': {
+            'index.js': `exports { * } from './whatever'`
+          },
+          'ember-inflector': {
+            'index.js': `exports { * } from './whateverElse'`
+          }
+        });
+
+        yield output.build();
+
+        expect(output.changes()).to.deep.equal({});
+      }));
+
+      it('should handle files in both modules folder and root with same name', co.wrap(function*() {
+        // INITIAL
+        input.write({
+          'modules': {
+            'ember-data': {
+              'whatever.js': `exports { * } from './whatever'`
+            }
+          },
+          'ember-data': {
+            'whateverElse.js': `exports { * } from './whateverElse'`
+          }
+        });
+
+        yield output.build();
+
+        expect(output.read()).to.deep.equal({
+          'ember-data': {
+            'whatever.js': `exports { * } from './whatever'`,
+            'whateverElse.js': `exports { * } from './whateverElse'`
+          }
+        });
+
+        yield output.build();
+
+        expect(output.changes()).to.deep.equal({});
+      }));
+
       it('should have updated the contents of the addon file if the addon updates its contents', co.wrap(function*() {
         // INITIAL
         input.write({


### PR DESCRIPTION
ember-data structures their tree like

/modules/ember-data/
/ember-inflector

The plugin needs to be modified to handle this case.