### PR TITLE
always call callback across rebuilds

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,10 +32,8 @@ module.exports = class ModuleNormalizer extends Plugin {
     if (fs.existsSync(modulesPath)) {
       modules = fs.readdirSync(modulesPath);
 
-      if (!this._hasRan) {
-        if (this.options.callback) {
-          this.options.callback();
-        }
+      if (this.options.callback) {
+        this.options.callback();
       }
     } else {
       modules = [];

--- a/test/index.js
+++ b/test/index.js
@@ -182,12 +182,6 @@ describe('Fix Module Folders', function() {
         yield output.build();
 
         expect(callback.calledOnce).to.be.ok;
-
-        callback.resetHistory();
-
-        yield output.build();
-
-        expect(callback.called).to.not.be.ok;
       }));
     });
   });


### PR DESCRIPTION
leave it up to the consumer to choose when to print the message